### PR TITLE
Allow multiple `resource_from_claims/1` signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,10 @@ defmodule MyApp.Guardian do
     {:error, :reason_for_error}
   end
 
-  def resource_from_claims(claims) do
+  def resource_from_claims(%{"sub" => id}) do
     # Here we'll look up our resource from the claims, the subject can be
     # found in the `"sub"` key. In above `subject_for_token/2` we returned
     # the resource id so here we'll rely on that to look it up.
-    id = claims["sub"]
     resource = MyApp.get_resource_by_id(id)
     {:ok,  resource}
   end


### PR DESCRIPTION
The way the example in the readme is currently written, no call would ever reach the error path, as the signature above's lack of pattern matching means that it would already act as the catchall case.